### PR TITLE
Emulation of Ele32 trigger for 2017BC

### DIFF
--- a/UMDNTuple/run_production_cfg.py
+++ b/UMDNTuple/run_production_cfg.py
@@ -184,6 +184,7 @@ if opt.year == 2017:
     '34:HLT_Ele200_CaloIdVT_GsfTrkIdT',
     '35:HLT_Ele250_CaloIdVT_GsfTrkIdT',
     '36:HLT_Ele300_CaloIdVT_GsfTrkIdT',
+    '2627:HLT_Ele32_WPTight_Gsf_L1DoubleEG_hltEGL1SingleEGOrFilter', # emulating HLT_Ele32_WPTight_Gsf
     # Photon triggers
     '40:HLT_Photon25',
     '41:HLT_Photon33',

--- a/UMDNTuple/src/ElectronProducer.cc
+++ b/UMDNTuple/src/ElectronProducer.cc
@@ -1,6 +1,7 @@
 #include "UMDNTuple/UMDNTuple/interface/ElectronProducer.h"
 #include "FWCore/Framework/interface/EDConsumerBase.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 ElectronProducer::ElectronProducer(  ) : 
     el_n(0),
@@ -48,7 +49,7 @@ ElectronProducer::ElectronProducer(  ) :
     el_ecalRecHitSumEt(0),
     el_hcalTowerSumEt(0),
     //_effectiveAreas("data/effAreaElectrons_cone03_pfNeuHadronsAndPhotons_80X.txt"),
-    _effectiveAreas( "src/UMDNTuple/UMDNTuple/data/effAreaElectrons_cone03_pfNeuHadronsAndPhotons_94X.txt" ),
+    _effectiveAreas( edm::FileInPath("UMDNTuple/UMDNTuple/data/effAreaElectrons_cone03_pfNeuHadronsAndPhotons_94X.txt").fullPath() ),
     _detail(99)
 {
 

--- a/UMDNTuple/src/PhotonProduer.cc
+++ b/UMDNTuple/src/PhotonProduer.cc
@@ -2,6 +2,7 @@
 #include "FWCore/Framework/interface/EDConsumerBase.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "RecoEgamma/EgammaTools/interface/EffectiveAreas.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 PhotonProducer::PhotonProducer(  ) : 
     ph_n(0),
@@ -54,9 +55,9 @@ PhotonProducer::PhotonProducer(  ) :
     ph_E2x5Full5x5(0),
     ph_E3x3Full5x5(0),
     ph_E5x5Full5x5(0),
-    _effectiveAreasCH("src/UMDNTuple/UMDNTuple/data/effAreaPhotons_cone03_pfChargedHadrons_90percentBased_V2.txt"),
-    _effectiveAreasNH("src/UMDNTuple/UMDNTuple/data/effAreaPhotons_cone03_pfNeutralHadrons_90percentBased_V2.txt"),
-    _effectiveAreasPH("src/UMDNTuple/UMDNTuple/data/effAreaPhotons_cone03_pfPhotons_90percentBased_V2.txt"),
+    _effectiveAreasCH( edm::FileInPath("UMDNTuple/UMDNTuple/data/effAreaPhotons_cone03_pfChargedHadrons_90percentBased_V2.txt").fullPath() ),
+    _effectiveAreasNH( edm::FileInPath("UMDNTuple/UMDNTuple/data/effAreaPhotons_cone03_pfNeutralHadrons_90percentBased_V2.txt").fullPath() ),
+    _effectiveAreasPH( edm::FileInPath("UMDNTuple/UMDNTuple/data/effAreaPhotons_cone03_pfPhotons_90percentBased_V2.txt").fullPath() ),
     _detail(0),
     _tree(0)
 {

--- a/UMDNTuple/src/TriggerProducer.cc
+++ b/UMDNTuple/src/TriggerProducer.cc
@@ -104,10 +104,23 @@ void TriggerProducer::produce(const edm::Event &iEvent ) {
         }
     }
 
+    // 2017: emulate HLT_Ele32_WPTight_Gsf as 'HLT_Ele32_WPTight_Gsf_L1DoubleEG' && 'hltEGL1SingleEGOrFilter'
+    // See https://twiki.cern.ch/twiki/bin/view/CMS/EgHLTRunIISummary#2017
+    int idx_Ele32L1DEGfilter = 2627; // ID of emulated trigger
+    int idx_Ele32L1DEG = 27;
+    std::string name_Ele32L1DEG = "HLT_Ele32_WPTight_Gsf_L1DoubleEG";
+    bool pass_HLT_Ele32_WPTight_Gsf_L1DoubleEG = false;
+    bool pass_hltEGL1SingleEGOrFilter = false;
+    
     for( std::vector<std::pair<int,int> >::const_iterator mitr = _trigger_idx_map.begin();
             mitr != _trigger_idx_map.end(); ++mitr ) {
         if( triggers->accept( mitr->first ) ) {
             _passing_triggers->push_back( mitr->second );
+            if (mitr->second == idx_Ele32L1DEG
+                && _trigger_map.find(name_Ele32L1DEG) != _trigger_map.end()
+                && _trigger_map[name_Ele32L1DEG] == idx_Ele32L1DEG) {
+                pass_HLT_Ele32_WPTight_Gsf_L1DoubleEG = true;
+            }
         }
     }
     for (unsigned j=0; j < triggerObjects->size();++j){
@@ -118,7 +131,7 @@ void TriggerProducer::produce(const edm::Event &iEvent ) {
         std::vector<std::string> pathNamesLast = obj.pathNames(true);
 
         std::vector<int> passed_trigs;
-
+        
         for( unsigned i = 0; i < pathNamesLast.size(); ++i ) {
             std::string pathname = pathNamesLast[i];
             if( pathname.substr(0,4) != "HLT_" ) continue; // ignore non "HLT" triggers
@@ -142,11 +155,25 @@ void TriggerProducer::produce(const edm::Event &iEvent ) {
             HLTObj_eta->push_back( obj.eta() );
             HLTObj_phi->push_back( obj.phi() );
             HLTObj_e->push_back( obj.energy() );
+            
+            if (pass_HLT_Ele32_WPTight_Gsf_L1DoubleEG) {
+                auto vitr = std::find(passed_trigs.begin(), passed_trigs.end(), idx_Ele32L1DEG);
+                if (vitr != passed_trigs.end()) {
+                    obj.unpackFilterLabels(iEvent, *triggers);
+                    bool obj_hltEGL1SingleEGOrFilter = obj.filter("hltEGL1SingleEGOrFilter");
+                    if (obj_hltEGL1SingleEGOrFilter) {
+                        pass_hltEGL1SingleEGOrFilter = true;
+                        passed_trigs.push_back(idx_Ele32L1DEGfilter);
+                    }
+                }
+            }
             HLTObj_passTriggers->push_back(passed_trigs);
         }
-
     }
-
+    // Add HLT_Ele32_WPTight_Gsf if HLT_Ele32_WPTight_Gsf_L1DoubleEG && hltEGL1SingleEGOrFilter
+    if (pass_HLT_Ele32_WPTight_Gsf_L1DoubleEG && pass_hltEGL1SingleEGOrFilter) {
+        _passing_triggers->push_back(idx_Ele32L1DEGfilter);
+    }
 }
 
 void TriggerProducer::endRun() {


### PR DESCRIPTION
Implemented emulation of `HLT_Ele32_WPTight` from `HLT_Ele32_WPTight_L1DoubleEG` + `hltEGL1SingleEGOrFilter` in periods where it was not available (2017BC), as suggested by https://twiki.cern.ch/twiki/bin/view/CMS/EgHLTRunIISummary#2017.
Stored as `2627:HLT_Ele32_WPTight_Gsf_L1DoubleEG_hltEGL1SingleEGOrFilter`.

![image](https://user-images.githubusercontent.com/1311783/67104538-6bbf5d00-f1c7-11e9-8f83-af150f3f180e.png)

![image](https://user-images.githubusercontent.com/1311783/67104995-4717b500-f1c8-11e9-8346-fa16c4f81bd3.png)
